### PR TITLE
chore: Add notice about new location

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!CAUTION]
+> This package has been moved to https://github.com/MetaMask/providers
+
 # MetaMask Inpage Provider
 
 The inpage Ethereum provider object injected by MetaMask into web pages.


### PR DESCRIPTION
This package was moved to a different repo over 5 years ago. A notice has been added about the move so that we can archive this repo.